### PR TITLE
Add vaadin-maven-plugin for production frontend build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,18 @@
                     <maxAttempts>240</maxAttempts>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-maven-plugin</artifactId>
+                <version>${vaadin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build-frontend</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
## Summary

- Add vaadin-maven-plugin with `build-frontend` goal to pom.xml
- Without the plugin, production builds (`mvn package`) skip frontend compilation
- The resulting JAR has no production bundle, so at startup Vaadin attempts dev mode initialization and fails with `RuntimeException: 'vaadin-dev-server' not found`
- This worked in Vaadin 25.0 because the missing bundle was tolerated, but 25.1 validates strictly