### PR TITLE
Use double literals for RangeSlider to support Vaadin 25.1 and 25.2

### DIFF
--- a/src/main/java/com/example/application/views/ComponentsView.java
+++ b/src/main/java/com/example/application/views/ComponentsView.java
@@ -126,8 +126,8 @@ public class ComponentsView extends VerticalLayout {
         slider.setValue(50.0);
         layout.add(slider);
 
-        RangeSlider rangeSlider = new RangeSlider("Price range", 0, 1000);
-        rangeSlider.setValue(new RangeSliderValue(200, 800));
+        RangeSlider rangeSlider = new RangeSlider("Price range", 0.0, 1000.0);
+        rangeSlider.setValue(new RangeSliderValue(200.0, 800.0));
         layout.add(rangeSlider);
 
         addComponentToGrid(layout);


### PR DESCRIPTION
## Summary

- Use `0.0`, `1000.0`, `200.0`, `800.0` instead of `0`, `1000`, `200`, `800` for RangeSlider constructors
- `RangeSliderValue` constructor changed from `(double, double)` to `(Double, Double)` in Vaadin 25.2
- Java does not auto-convert `int` to `Double` (wrapper), causing compilation error
- Double literals work with both 25.1 and 25.2

Fixes #8